### PR TITLE
Refine feather agent orchestration and Socratic chat

### DIFF
--- a/build/agents.manifest.json
+++ b/build/agents.manifest.json
@@ -4,14 +4,16 @@
     "promptPath": "clo_v3_1.yml",
     "defaultPromptVersion": "3.1",
     "entitlement": "core",
-    "mode": "weekly"
+    "mode": "weekly",
+    "phases": ["lecture", "comprehension", "practice"]
   },
   "socratic": {
     "id": "socratic",
     "promptPath": "socratic_v3_1.yml",
     "defaultPromptVersion": "3.1",
     "entitlement": "core",
-    "mode": "weekly"
+    "mode": "weekly",
+    "phases": ["comprehension", "reflection"]
   },
   "alex": {
     "id": "alex",
@@ -39,7 +41,8 @@
     "promptPath": "taagent_v1_5.yml",
     "defaultPromptVersion": "1.5",
     "entitlement": "core",
-    "mode": "weekly"
+    "mode": "weekly",
+    "phases": ["practice", "reflection"]
   },
   "career_match": {
     "id": "career_match",
@@ -60,7 +63,8 @@
     "promptPath": "instructor_v2_2.yml",
     "defaultPromptVersion": "2.2",
     "entitlement": "core",
-    "mode": "weekly"
+    "mode": "weekly",
+    "phases": ["lecture", "comprehension", "practice"]
   },
   "clarifier": {
     "id": "clarifier",

--- a/src/lib/agents/registry.ts
+++ b/src/lib/agents/registry.ts
@@ -24,6 +24,8 @@ export type Entitlement = "core" | "premium";
  */
 export type OrchestrationMode = "weekly" | "adhoc";
 
+import type { FeatherPhaseId } from '../feather-agent';
+
 export type AgentMeta = {
   id: AgentId;
   title: string;                 // Short human label
@@ -38,6 +40,7 @@ export type AgentMeta = {
   persistsTo: "agent_results" | "weekly_notes" | "both";
   rateLimitPerMin?: number;      // Soft client limit
   displayOrder: number;          // For menus/grids
+  phases?: FeatherPhaseId[];     // Feather-agent phase identifiers
 };
 
 export const AGENTS: Record<AgentId, AgentMeta> = {
@@ -54,7 +57,8 @@ export const AGENTS: Record<AgentId, AgentMeta> = {
     defaultPromptVersion: "3.1",
     persistsTo: "both",
     rateLimitPerMin: 4,
-    displayOrder: 10
+    displayOrder: 10,
+    phases: ["lecture", "comprehension", "practice"],
   },
   socratic: {
     id: "socratic",
@@ -69,7 +73,8 @@ export const AGENTS: Record<AgentId, AgentMeta> = {
     defaultPromptVersion: "3.1",
     persistsTo: "both",
     rateLimitPerMin: 8,
-    displayOrder: 20
+    displayOrder: 20,
+    phases: ["comprehension", "reflection"],
   },
   alex: {
     id: "alex",
@@ -129,7 +134,8 @@ export const AGENTS: Record<AgentId, AgentMeta> = {
     defaultPromptVersion: "1.5",
     persistsTo: "both",
     rateLimitPerMin: 6,
-    displayOrder: 40
+    displayOrder: 40,
+    phases: ["practice", "reflection"],
   },
   career_match: {
     id: "career_match",
@@ -174,7 +180,8 @@ export const AGENTS: Record<AgentId, AgentMeta> = {
     defaultPromptVersion: "2.2",
     persistsTo: "agent_results",
     rateLimitPerMin: 4,
-    displayOrder: 15
+    displayOrder: 15,
+    phases: ["lecture", "comprehension", "practice"],
   },
   clarifier: {
     id: "clarifier",

--- a/src/lib/feather-agent/client.ts
+++ b/src/lib/feather-agent/client.ts
@@ -1,0 +1,59 @@
+import type { FeatherRun, FeatherRunRequest, FeatherRunResponse } from './types';
+
+export interface FeatherAgentClientOptions {
+  baseUrl: string;
+  anonKey: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class FeatherAgentClient {
+  private readonly baseUrl: string;
+  private readonly anonKey: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: FeatherAgentClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+    this.anonKey = options.anonKey;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async run<T extends FeatherRun = FeatherRun>(
+    functionName: string,
+    request: FeatherRunRequest,
+  ): Promise<FeatherRunResponse<T>> {
+    const response = await this.fetchImpl(`${this.baseUrl}/functions/v1/${functionName}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.anonKey}`,
+        'apikey': this.anonKey,
+      },
+      body: JSON.stringify(request),
+    });
+
+    const json = await response.json();
+    if (!response.ok) {
+      return {
+        success: false,
+        error: json?.error || `Request failed with status ${response.status}`,
+        data: json?.data,
+      } as FeatherRunResponse<T>;
+    }
+
+    return json as FeatherRunResponse<T>;
+  }
+}
+
+export function extractPhaseArtifact<T = unknown>(
+  run: FeatherRun,
+  phaseId: string,
+  artifactKind?: string,
+): T | undefined {
+  const phase = run.phases.find((p) => p.id === phaseId);
+  if (!phase) return undefined;
+  if (!artifactKind) {
+    return phase.artifacts[0]?.data as T | undefined;
+  }
+  const artifact = phase.artifacts.find((a) => a.kind === artifactKind);
+  return artifact?.data as T | undefined;
+}

--- a/src/lib/feather-agent/index.ts
+++ b/src/lib/feather-agent/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './client';

--- a/src/lib/feather-agent/types.ts
+++ b/src/lib/feather-agent/types.ts
@@ -1,0 +1,54 @@
+export type FeatherPhaseId =
+  | 'lecture'
+  | 'comprehension'
+  | 'practice'
+  | 'reflection'
+  | 'planning'
+  | 'analysis';
+
+export type FeatherRunStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface FeatherArtifact<T = unknown> {
+  id: string;
+  kind: string;
+  label?: string;
+  data: T;
+  meta?: Record<string, unknown>;
+  createdAt?: string;
+}
+
+export interface FeatherPhase<T = FeatherArtifact> {
+  id: FeatherPhaseId | string;
+  label: string;
+  status: FeatherRunStatus;
+  summary?: string;
+  meta?: Record<string, unknown>;
+  artifacts: T[];
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface FeatherRun<TPhase extends FeatherPhase = FeatherPhase> {
+  runId: string;
+  agentId: string;
+  status: FeatherRunStatus;
+  startedAt: string;
+  completedAt?: string;
+  action: string;
+  phases: TPhase[];
+  state?: Record<string, unknown>;
+  instructorModifications?: Record<string, unknown>;
+}
+
+export interface FeatherRunResponse<TPhase extends FeatherPhase = FeatherPhase> {
+  success: boolean;
+  data?: FeatherRun<TPhase>;
+  error?: string;
+}
+
+export interface FeatherRunRequest {
+  userId: string;
+  action: string;
+  payload?: Record<string, unknown>;
+  instructorModifications?: Record<string, unknown>;
+}

--- a/supabase/functions/_shared/feather/runtime.ts
+++ b/supabase/functions/_shared/feather/runtime.ts
@@ -1,0 +1,173 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import {
+  FeatherArtifact,
+  FeatherPhase,
+  FeatherRuntimeConfig,
+  FeatherRunRequest,
+  FeatherRunResult,
+  FeatherTaskContext,
+} from './types.ts';
+
+const DEFAULT_CORS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function buildSupabaseClient() {
+  return createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  );
+}
+
+interface HandleRequestOptions {
+  onComplete?: (result: FeatherRunResult) => Promise<void> | void;
+}
+
+export function createFeatherRuntime(config: FeatherRuntimeConfig) {
+  const corsHeaders = { ...DEFAULT_CORS, ...(config.corsHeaders ?? {}) };
+
+  const executeRun = async (
+    payload: FeatherRunRequest,
+    options: HandleRequestOptions = {},
+  ): Promise<{ ok: boolean; result: FeatherRunResult; error?: Error }> => {
+    if (!payload?.userId || !payload?.action) {
+      throw new Error('userId and action are required');
+    }
+
+    const runId = crypto.randomUUID();
+    const supabase = config.getSupabaseClient ? config.getSupabaseClient() : buildSupabaseClient();
+    const startedAt = nowIso();
+
+    const phases: FeatherPhase[] = config.tasks.map((task) => ({
+      id: task.phaseId,
+      label: task.label ?? task.phaseId,
+      status: 'pending',
+      artifacts: [],
+    }));
+
+    const state: Record<string, unknown> = {};
+
+    const log = (message: string, meta: Record<string, unknown> = {}) => {
+      console.log(`[feather:${config.agentId}] ${message}`, meta);
+    };
+
+    const getPhaseById = (phaseId: FeatherPhase['id']) => {
+      const phase = phases.find((p) => p.id === phaseId);
+      if (!phase) {
+        throw new Error(`Unknown phase ${phaseId}`);
+      }
+      return phase;
+    };
+
+    try {
+      for (const task of config.tasks) {
+        const phase = getPhaseById(task.phaseId);
+        phase.status = 'running';
+        phase.startedAt = nowIso();
+
+        const context: FeatherTaskContext = {
+          request: payload,
+          phase,
+          supabase,
+          state,
+          log,
+          emitArtifact: (artifact: FeatherArtifact) => {
+            phase.artifacts.push({ ...artifact, createdAt: artifact.createdAt ?? nowIso() });
+          },
+          setPhaseMeta: (meta: Record<string, unknown>) => {
+            phase.meta = { ...(phase.meta ?? {}), ...meta };
+          },
+          setPhaseSummary: (summary: string) => {
+            phase.summary = summary;
+          },
+        };
+
+        await task.run(context);
+
+        phase.status = 'completed';
+        phase.completedAt = nowIso();
+      }
+
+      const result: FeatherRunResult = {
+        runId,
+        agentId: config.agentId,
+        status: 'completed',
+        startedAt,
+        completedAt: nowIso(),
+        action: payload.action,
+        phases,
+        state,
+        instructorModifications: payload.instructorModifications,
+      };
+
+      await options.onComplete?.(result);
+
+      return { ok: true, result };
+    } catch (error) {
+      const failedResult: FeatherRunResult = {
+        runId,
+        agentId: config.agentId,
+        status: 'failed',
+        startedAt,
+        action: payload.action,
+        phases,
+        state,
+        instructorModifications: payload.instructorModifications,
+      };
+
+      return { ok: false, result: failedResult, error: error instanceof Error ? error : new Error(String(error)) };
+    }
+  };
+
+  async function handleRequest(req: Request, options: HandleRequestOptions = {}) {
+    if (req.method === 'OPTIONS') {
+      return new Response('ok', { headers: corsHeaders });
+    }
+
+    let payload: FeatherRunRequest;
+
+    try {
+      payload = await req.json();
+    } catch (error) {
+      console.error(`[feather:${config.agentId}] Failed to parse request`, error);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invalid request payload' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 },
+      );
+    }
+
+    try {
+      const { ok, result, error } = await executeRun(payload, options);
+
+      if (!ok) {
+        console.error(`[feather:${config.agentId}] runtime failure`, error);
+        return new Response(
+          JSON.stringify({ success: false, error: error?.message ?? 'Runtime failure', data: result }),
+          { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 500 },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({ success: true, data: result }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    } catch (error) {
+      console.error(`[feather:${config.agentId}] unhandled runtime failure`, error);
+      return new Response(
+        JSON.stringify({ success: false, error: error.message ?? 'Runtime error' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 500 },
+      );
+    }
+  }
+
+  return {
+    handleRequest,
+    execute: executeRun,
+    corsHeaders,
+  };
+}

--- a/supabase/functions/_shared/feather/types.ts
+++ b/supabase/functions/_shared/feather/types.ts
@@ -1,0 +1,75 @@
+export type FeatherPhaseId =
+  | 'lecture'
+  | 'comprehension'
+  | 'practice'
+  | 'reflection'
+  | 'planning'
+  | 'analysis';
+
+export type FeatherRunStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface FeatherRunRequest {
+  userId: string;
+  action: string;
+  payload?: Record<string, unknown>;
+  instructorModifications?: Record<string, unknown>;
+}
+
+export interface FeatherArtifact<T = unknown> {
+  id: string;
+  kind: string;
+  label?: string;
+  data: T;
+  meta?: Record<string, unknown>;
+  createdAt?: string;
+}
+
+export interface FeatherPhase<TArtifacts extends FeatherArtifact = FeatherArtifact> {
+  id: FeatherPhaseId | string;
+  label: string;
+  status: FeatherRunStatus;
+  summary?: string;
+  artifacts: TArtifacts[];
+  meta?: Record<string, unknown>;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface FeatherRunResult<TPhase extends FeatherPhase = FeatherPhase> {
+  runId: string;
+  agentId: string;
+  status: FeatherRunStatus;
+  startedAt: string;
+  completedAt?: string;
+  action: string;
+  phases: TPhase[];
+  state?: Record<string, unknown>;
+  instructorModifications?: Record<string, unknown>;
+}
+
+export interface FeatherTaskContext {
+  request: FeatherRunRequest;
+  phase: FeatherPhase;
+  supabase: any;
+  state: Record<string, unknown>;
+  log: (message: string, meta?: Record<string, unknown>) => void;
+  emitArtifact: (artifact: FeatherArtifact) => void;
+  setPhaseMeta: (meta: Record<string, unknown>) => void;
+  setPhaseSummary: (summary: string) => void;
+}
+
+export interface FeatherTaskDefinition {
+  id: string;
+  phaseId: FeatherPhase['id'];
+  label?: string;
+  description?: string;
+  run: (ctx: FeatherTaskContext) => Promise<void>;
+}
+
+export interface FeatherRuntimeConfig {
+  agentId: string;
+  label: string;
+  tasks: FeatherTaskDefinition[];
+  corsHeaders?: Record<string, string>;
+  getSupabaseClient?: () => any;
+}

--- a/supabase/functions/clo-agent/index.ts
+++ b/supabase/functions/clo-agent/index.ts
@@ -1,454 +1,305 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createFeatherRuntime } from "../_shared/feather/runtime.ts";
+import { FeatherTaskContext } from "../_shared/feather/types.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+type SupabaseClient = ReturnType<typeof createClient>;
+
+interface CLOLearningPreferences {
+  focus_areas?: string[];
+  preferred_interaction_style?: string;
+  core_competencies?: string[];
 }
 
-// Simple in-memory rate limiter (in production, use Redis or database)
-const rateLimitMap = new Map<string, number>()
-const RATE_LIMIT_WINDOW = 5000 // 5 seconds
+interface CLOUserProfile {
+  name?: string;
+  learning_preferences?: CLOLearningPreferences;
+  hardware_specs?: string;
+  end_goal?: string;
+}
 
-// Clean up old rate limit entries every 10 minutes
+interface CLORequestPayload {
+  weekNumber?: number;
+  timePerWeek?: number;
+  [key: string]: unknown;
+}
+
+const rateLimitMap = new Map<string, number>();
+const RATE_LIMIT_WINDOW_MS = 5000;
+
 setInterval(() => {
-  const now = Date.now()
+  const now = Date.now();
   for (const [userId, timestamp] of rateLimitMap.entries()) {
-    if (now - timestamp > RATE_LIMIT_WINDOW * 2) {
-      rateLimitMap.delete(userId)
+    if (now - timestamp > RATE_LIMIT_WINDOW_MS * 2) {
+      rateLimitMap.delete(userId);
     }
   }
-}, 600000) // 10 minutes
+}, RATE_LIMIT_WINDOW_MS * 12);
 
-interface CLORequest {
-  action: string;
-  payload: any;
-  userId: string;
-}
+const runtime = createFeatherRuntime({
+  agentId: "clo",
+  label: "Chief Learning Officer",
+  tasks: [
+    {
+      id: "generate-weekly-lecture",
+      phaseId: "lecture",
+      label: "Weekly Lecture",
+      run: runLecturePhase,
+    },
+    {
+      id: "generate-comprehension",
+      phaseId: "comprehension",
+      label: "Comprehension Check",
+      run: runComprehensionPhase,
+    },
+    {
+      id: "generate-practice",
+      phaseId: "practice",
+      label: "Practice Personalization",
+      run: runPracticePhase,
+    },
+  ],
+});
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: runtime.corsHeaders });
   }
 
-  try {
-    const { action, payload, userId }: CLORequest = await req.json()
+  const payload = await req.json();
 
-    // Rate limiting check
-    const now = Date.now()
-    const lastCall = rateLimitMap.get(userId)
-    if (lastCall && (now - lastCall) < RATE_LIMIT_WINDOW) {
-      console.log(`Rate limited for user ${userId}, last call was ${now - lastCall}ms ago`)
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: 'Rate limited. Please wait a few seconds before trying again.'
-        }),
-        {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-          status: 429,
-        },
-      )
-    }
-    
-    // Update rate limit
-    rateLimitMap.set(userId, now)
-
-    console.log('CLO Agent called with:', { action, payload, userId })
-
-    // Initialize Supabase client
-    const supabaseClient = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
-    )
-
-    console.log('Supabase client initialized')
-
-    // Load CLO prompt from storage
-    const { data: promptData, error: promptError } = await supabaseClient.storage
-      .from('prompts')
-      .download('clo_v3.md')
-
-    if (promptError || !promptData) {
-      console.error('Prompt loading failed:', promptError)
-      throw new Error(`Failed to load CLO prompt: ${promptError?.message || 'No prompt data'}`)
-    }
-
-    console.log('Prompt loaded successfully, size:', promptData.size)
-
-    const promptText = await promptData.text()
-
-    // Get user profile and context
-    const { data: userProfile, error: userError } = await supabaseClient
-      .from('users')
-      .select('*')
-      .eq('id', userId)
-      .single()
-
-    if (userError) {
-      console.error('User profile fetch failed:', userError)
-      throw new Error(`Failed to fetch user profile: ${userError.message}`)
-    }
-
-    console.log('User profile fetched:', { name: userProfile?.name, focusAreas: userProfile?.learning_preferences?.focus_areas })
-
-    // Get current week
-    const currentWeek = Math.ceil((Date.now() - new Date('2024-01-01').getTime()) / (7 * 24 * 60 * 60 * 1000))
-
-    console.log('Current week calculated:', currentWeek)
-
-    // Format prompt with user context
-    const formattedPrompt = promptText
-      .replace(/{{LEARNER_NAME}}/g, userProfile?.name || 'Learner')
-      .replace(/{{TRACK_LABEL}}/g, userProfile?.learning_preferences?.focus_areas?.[0] || 'Full-Stack Development')
-      .replace(/{{TIME_PER_WEEK}}/g, payload.timePerWeek || '5')
-      .replace(/{{HARDWARE_SPECS}}/g, 'basic laptop') // Default since not stored
-      .replace(/{{LEARNING_STYLE}}/g, userProfile?.learning_preferences?.preferred_interaction_style || 'mixed')
-      .replace(/{{END_GOAL}}/g, 'Master full-stack development fundamentals') // Default since not stored
-      .replace(/{{BUDGET_JSON}}/g, JSON.stringify({ budget: 0 })) // Default since not stored
-      .replace(/{{CORE_COMPETENCY_BLOCK}}/g, 'Full-Stack Development, React, TypeScript, Web Technologies')
-      .replace(/{{MONTH_GOALS_JSON}}/g, JSON.stringify({ goals: ['Build foundation', 'Complete projects', 'Master concepts'] }))
-
-    console.log('Prompt formatted successfully')
-
-    // Call Gemini API with formatted prompt
-    const geminiResponse = await callGeminiAPI(formattedPrompt, action, payload, currentWeek)
-
-    if (geminiResponse.success) {
-      console.log('Gemini API call successful')
-      return new Response(
-        JSON.stringify({ success: true, data: geminiResponse.data }),
-        {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-          status: 200,
-        },
-      )
-    } else {
-      console.error('Gemini API call failed:', geminiResponse.error)
-      throw new Error(geminiResponse.error)
-    }
-
-  } catch (error) {
-    console.error('CLO Agent error:', error)
+  const userId: string | undefined = payload?.userId;
+  if (!userId) {
     return new Response(
-      JSON.stringify({
-        success: false,
-        error: error.message
+      JSON.stringify({ success: false, error: "userId is required" }),
+      { headers: { ...runtime.corsHeaders, "Content-Type": "application/json" }, status: 400 },
+    );
+  }
+
+  const now = Date.now();
+  const lastCall = rateLimitMap.get(userId);
+  if (lastCall && now - lastCall < RATE_LIMIT_WINDOW_MS) {
+    return new Response(
+      JSON.stringify({ success: false, error: "Rate limited. Please wait a few seconds before trying again." }),
+      { headers: { ...runtime.corsHeaders, "Content-Type": "application/json" }, status: 429 },
+    );
+  }
+  rateLimitMap.set(userId, now);
+
+  const proxyRequest = new Request(req.url, {
+    method: req.method,
+    headers: req.headers,
+    body: JSON.stringify(payload),
+  });
+
+  return runtime.handleRequest(proxyRequest);
+});
+
+async function runLecturePhase(ctx: FeatherTaskContext) {
+  const requestPayload = (ctx.request.payload || {}) as CLORequestPayload;
+  const weekNumber = typeof requestPayload.weekNumber === "number"
+    ? requestPayload.weekNumber
+    : await resolveCurrentWeek();
+
+  const supabase: SupabaseClient = (ctx.supabase as SupabaseClient) ?? createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  );
+
+  const prompt = await loadPrompt(supabase, "prompts", "clo_v3.md");
+  const userProfile = await loadUserProfile(supabase, ctx.request.userId);
+
+  const formattedPrompt = formatPrompt(prompt, userProfile, requestPayload, weekNumber, ctx.request.action);
+  const geminiResult = await callGeminiAPI(formattedPrompt, ctx.request.action, weekNumber);
+
+  ctx.state.weekNumber = weekNumber;
+  ctx.state.lecture = geminiResult;
+
+  ctx.emitArtifact({
+    id: `clo-lecture-${weekNumber}`,
+    kind: "weekly_plan",
+    label: `Week ${weekNumber} lecture plan`,
+    data: geminiResult.data,
+    meta: {
+      weekNumber,
+      generatedAt: new Date().toISOString(),
+    },
+  });
+
+  ctx.setPhaseSummary(geminiResult.data?.summary || `Generated lecture plan for week ${weekNumber}`);
+}
+
+async function runComprehensionPhase(ctx: FeatherTaskContext) {
+  const lectureData = ctx.state.lecture?.data ?? {};
+  const questions = lectureData?.comprehension_questions || lectureData?.CLO_Assessor_Directive?.comprehension_check || [];
+
+  const normalized = Array.isArray(questions)
+    ? questions
+    : Object.values(questions || {}).map((question, index) => ({
+      id: `q${index + 1}`,
+      question,
+    }));
+
+  const enrichedQuestions = normalized.length > 0
+    ? normalized
+    : [
+      { id: "q1", question: "What is the primary objective for this week?" },
+      { id: "q2", question: "How will you apply the new concepts in practice?" },
+    ];
+
+  ctx.emitArtifact({
+    id: `clo-comprehension-${ctx.state.weekNumber}`,
+    kind: "question_list",
+    label: "Comprehension Check",
+    data: { questions: enrichedQuestions },
+    meta: { count: enrichedQuestions.length },
+  });
+
+  ctx.setPhaseSummary(`Generated ${enrichedQuestions.length} comprehension questions.`);
+}
+
+async function runPracticePhase(ctx: FeatherTaskContext) {
+  const lectureData = ctx.state.lecture?.data ?? {};
+  const practice = lectureData?.practice_prompts || lectureData?.CLO_Assessor_Directive?.practice_prompts || [];
+
+  const normalized = Array.isArray(practice)
+    ? practice
+    : Object.values(practice || {}).map((prompt, index) => ({
+      id: `practice-${index + 1}`,
+      prompt,
+    }));
+
+  const practicePrompts = normalized.length > 0
+    ? normalized
+    : [
+      { id: "practice-1", prompt: "Complete the core exercise outlined by the CLO." },
+      { id: "practice-2", prompt: "Document blockers and questions for the TA." },
+    ];
+
+  ctx.emitArtifact({
+    id: `clo-practice-${ctx.state.weekNumber}`,
+    kind: "practice_plan",
+    label: "Practice Personalization",
+    data: { prompts: practicePrompts },
+    meta: {
+      count: practicePrompts.length,
+      taHandoff: lectureData?.CLO_Assessor_Directive?.ta_handoff || null,
+    },
+  });
+
+  ctx.setPhaseSummary(`Prepared practice guidance with ${practicePrompts.length} prompts.`);
+}
+
+async function loadPrompt(supabase: SupabaseClient, bucket: string, path: string) {
+  const { data, error } = await supabase.storage.from(bucket).download(path);
+  if (error || !data) {
+    throw new Error(`Failed to load CLO prompt: ${error?.message ?? "unknown error"}`);
+  }
+  return await data.text();
+}
+
+async function loadUserProfile(supabase: SupabaseClient, userId: string): Promise<CLOUserProfile> {
+  const { data, error } = await supabase.from('users').select('*').eq('id', userId).single();
+  if (error) {
+    throw new Error(`Failed to fetch user profile: ${error.message}`);
+  }
+  return data as CLOUserProfile;
+}
+
+function formatPrompt(
+  prompt: string,
+  userProfile: CLOUserProfile,
+  payload: CLORequestPayload,
+  weekNumber: number,
+  action: string,
+) {
+  const preferences = userProfile?.learning_preferences ?? {};
+  return prompt
+    .replace(/{{LEARNER_NAME}}/g, userProfile?.name || 'Learner')
+    .replace(/{{TRACK_LABEL}}/g, preferences?.focus_areas?.[0] || 'Full-Stack Development')
+    .replace(/{{TIME_PER_WEEK}}/g, String(payload.timePerWeek || 5))
+    .replace(/{{HARDWARE_SPECS}}/g, userProfile?.hardware_specs || 'basic laptop')
+    .replace(/{{LEARNING_STYLE}}/g, preferences?.preferred_interaction_style || 'mixed')
+    .replace(/{{END_GOAL}}/g, userProfile?.end_goal || 'Master core engineering fundamentals')
+    .replace(/{{BUDGET_JSON}}/g, JSON.stringify({ budget: 0 }))
+    .replace(/{{CORE_COMPETENCY_BLOCK}}/g, preferences?.core_competencies?.join(', ') || 'Full-Stack Development, React, TypeScript')
+    .replace(/{{MONTH_GOALS_JSON}}/g, JSON.stringify({ goals: ['Build foundation', 'Complete projects', 'Master concepts'] }))
+    .concat(`\n\nCommand: ${mapActionToCommand(action, weekNumber)}`);
+}
+
+async function callGeminiAPI(
+  prompt: string,
+  action: string,
+  weekNumber: number,
+) {
+  const geminiApiKey = Deno.env.get('VITE_GEMINI_API_KEY');
+  if (!geminiApiKey) {
+    throw new Error('VITE_GEMINI_API_KEY not configured');
+  }
+
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${geminiApiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [
+              {
+                text: `${prompt}\n\nGenerate a comprehensive weekly learning plan for week ${weekNumber}. Include all required sections and return JSON.`,
+              },
+            ],
+          },
+        ],
       }),
-      {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 500,
-      },
-    )
-  }
-})
+    },
+  );
 
-async function callGeminiAPI(prompt: string, action: string, payload: any, weekNumber: number) {
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Gemini API error: ${response.status} ${response.statusText} - ${errorBody}`);
+  }
+
+  const data = await response.json();
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+  const parsed = extractJson(text) ?? { raw_response: text };
+  const command = mapActionToCommand(action, weekNumber);
+
+  return {
+    success: true,
+    data: {
+      ...parsed,
+      raw_response: text,
+      week_number: weekNumber,
+      command_executed: command,
+    },
+  };
+}
+
+function extractJson(text: string) {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return null;
   try {
-    console.log('Starting Gemini API call...')
-    
-    const geminiApiKey = Deno.env.get('VITE_GEMINI_API_KEY')
-    if (!geminiApiKey) {
-      console.error('VITE_GEMINI_API_KEY not configured')
-      throw new Error('VITE_GEMINI_API_KEY not configured')
-    }
-
-    console.log('Gemini API key found, length:', geminiApiKey.length)
-
-    // Map our actions to the prompt's expected commands
-    let command;
-    if (action === 'GET_DAILY_LESSON') {
-      command = 'BEGIN_WEEK';
-    } else if (action === 'GET_WEEKLY_PLAN') {
-      command = 'BEGIN_WEEK';
-    } else {
-      command = action;
-    }
-
-    console.log('Command mapped:', { action, command })
-
-    const geminiPrompt = `${prompt}\n\nCommand: ${command}\n\nGenerate a comprehensive weekly learning plan for week ${weekNumber}. Include all required sections from the prompt template.`
-
-    console.log('Calling Gemini API...')
-
-    const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${geminiApiKey}`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          contents: [{
-            parts: [{
-              text: geminiPrompt
-            }]
-          }]
-        })
-      }
-    )
-
-    console.log('Gemini API response status:', response.status)
-
-    if (!response.ok) {
-      const errorText = await response.text()
-      console.error('Gemini API error response:', errorText)
-      throw new Error(`Gemini API error: ${response.status} ${response.statusText}`)
-    }
-
-    const data = await response.json()
-    console.log('Gemini API response received, candidates:', data.candidates?.length || 0)
-    console.log('Full Gemini API response:', JSON.stringify(data, null, 2))
-    
-    const generatedText = data.candidates[0]?.content?.parts[0]?.text || ''
-    console.log('Generated text length:', generatedText.length)
-    console.log('Generated text content:', generatedText)
-
-    // Parse the response based on the action
-    if (action === 'GET_DAILY_LESSON' || action === 'GET_WEEKLY_PLAN') {
-      console.log('Extracting structured data from response...')
-      return {
-        success: true,
-        data: {
-          title: extractDailyTitle(generatedText) || 'Weekly Learning Module',
-          description: extractWeeklyDescription(generatedText) || 'Comprehensive weekly learning plan',
-          objectives: extractDailyObjectives(generatedText) || ['Master core concepts', 'Complete practical exercises', 'Build foundational knowledge'],
-          key_concepts: extractKeyConcepts(generatedText) || ['Full-Stack Development Fundamentals', 'React Best Practices', 'TypeScript Programming'],
-          resources: extractResources(generatedText) || ['Online tutorials', 'Documentation', 'Practice exercises'],
-          content: generatedText, // Return the full generated content
-          exercises: extractDailyExercises(generatedText) || ['Practice exercises', 'Mini-projects', 'Code challenges'],
-          estimated_duration: extractDailyDuration(generatedText) || 25,
-          weekly_summary: extractWeeklySummary(generatedText) || 'Weekly learning module with comprehensive coverage',
-          daily_breakdown: extractDailyBreakdown(generatedText) || ['Day 1: Foundation', 'Day 2: Practice', 'Day 3: Application', 'Day 4: Review', 'Day 5: Assessment'],
-          plan_duration: extractPlanDuration(generatedText) || 5,
-          fullContent: generatedText // Store the complete response
-        }
-      }
-    }
-
-    return {
-      success: true,
-      data: {
-        message: generatedText
-      }
-    }
-
+    return JSON.parse(match[0]);
   } catch (error) {
-    console.error('callGeminiAPI error:', error)
-    return {
-      success: false,
-      error: error.message
-    }
+    console.warn('Failed to parse CLO JSON response', error);
+    return null;
   }
 }
 
-// Helper functions to extract information from Gemini response
-function extractDailyTitle(text: string): string {
-  // Look for various title patterns in the response
-  const patterns = [
-    /Weekly Theme[^\n]*: ([^\n]+)/i,
-    /Week \d+[^\n]*: ([^\n]+)/i,
-    /Module[^\n]*: ([^\n]+)/i,
-    /^#\s*([^\n]+)/m
-  ]
-  
-  for (const pattern of patterns) {
-    const match = text.match(pattern)
-    if (match) return match[1].trim()
+function mapActionToCommand(action: string | undefined, weekNumber: number) {
+  const normalized = action ?? '';
+  switch (normalized) {
+    case 'GET_DAILY_LESSON':
+    case 'GET_WEEKLY_PLAN':
+      return `BEGIN_WEEK_${weekNumber}`;
+    default:
+      return normalized || 'BEGIN_WEEK';
   }
-  
-  return 'Weekly Learning Module'
 }
 
-function extractWeeklyDescription(text: string): string {
-  // Look for description after the title
-  const titleMatch = extractDailyTitle(text)
-  if (titleMatch !== 'Weekly Learning Module') {
-    // Find the next few lines after the title for description
-    const lines = text.split('\n')
-    const titleIndex = lines.findIndex(line => line.includes(titleMatch))
-    if (titleIndex >= 0 && titleIndex + 1 < lines.length) {
-      const description = lines[titleIndex + 1].trim()
-      if (description && !description.startsWith('**') && description.length > 10) {
-        return description
-      }
-    }
-  }
-  return 'Comprehensive weekly learning plan'
-}
-
-function extractDailyObjectives(text: string): string[] {
-  const patterns = [
-    /SMART Learning Objectives[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i,
-    /Learning Objectives[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i,
-    /Objectives[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i
-  ]
-  
-  for (const pattern of patterns) {
-    const objectivesMatch = text.match(pattern)
-    if (objectivesMatch) {
-      const objectivesText = objectivesMatch[1]
-      const objectives = objectivesText.match(/\d+\.\s*([^\n]+)/g)
-      if (objectives && objectives.length > 0) {
-        return objectives.map(obj => obj.replace(/\d+\.\s*/, '').trim()).filter(obj => obj.length > 5)
-      }
-    }
-  }
-  
-  // Fallback: look for numbered lists that might be objectives
-  const numberedLines = text.match(/\d+\.\s*([^\n]+)/g)
-  if (numberedLines && numberedLines.length > 0) {
-    return numberedLines.slice(0, 5).map(obj => obj.replace(/\d+\.\s*/, '').trim()).filter(obj => obj.length > 5)
-  }
-  
-  return ['Master core concepts', 'Complete practical exercises', 'Build foundational knowledge']
-}
-
-function extractWeeklyObjectives(text: string): string[] {
-  return extractDailyObjectives(text)
-}
-
-function extractKeyConcepts(text: string): string[] {
-  const patterns = [
-    /Core Theoretical Concepts[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i,
-    /Key Concepts[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i,
-    /Theoretical Concepts[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i
-  ]
-  
-  for (const pattern of patterns) {
-    const conceptsMatch = text.match(pattern)
-    if (conceptsMatch) {
-      const conceptsText = conceptsMatch[1]
-      const concepts = conceptsText.match(/\d+\.\s*([^\n]+)/g)
-      if (concepts && concepts.length > 0) {
-        return concepts.map(concept => concept.replace(/\d+\.\s*/, '').trim()).filter(concept => concept.length > 5)
-      }
-    }
-  }
-  
-  return ['Full-Stack Development Fundamentals', 'React Best Practices', 'TypeScript Programming']
-}
-
-function extractResources(text: string): string[] {
-  const patterns = [
-    /Curated Resources[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i,
-    /Resources[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i,
-    /Learning Resources[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i
-  ]
-  
-  for (const pattern of patterns) {
-    const resourcesMatch = text.match(pattern)
-    if (resourcesMatch) {
-      const resourcesText = resourcesMatch[1]
-      const resources = resourcesText.match(/\d+\.\s*([^\n]+)/g)
-      if (resources && resources.length > 0) {
-        return resources.map(resource => resource.replace(/\d+\.\s*/, '').trim()).filter(resource => resource.length > 5)
-      }
-    }
-  }
-  
-  return ['Online tutorials', 'Documentation', 'Practice exercises']
-}
-
-function extractDailyContent(text: string): string {
-  // Return a summary of the content instead of the full text
-  const lines = text.split('\n').slice(0, 10) // First 10 lines
-  return lines.join('\n').trim()
-}
-
-function extractDailyExercises(text: string): string[] {
-  const patterns = [
-    /Capstone Project[^\n]*:([\s\S]*?)(?=\n\n|$)/i,
-    /Practice Exercises[^\n]*:([\s\S]*?)(?=\n\n|$)/i,
-    /Exercises[^\n]*:([\s\S]*?)(?=\n\n|$)/i
-  ]
-  
-  for (const pattern of patterns) {
-    const exercisesMatch = text.match(pattern)
-    if (exercisesMatch) {
-      const exercisesText = exercisesMatch[1]
-      const exercises = exercisesText.match(/\d+\.\s*([^\n]+)/g)
-      if (exercises && exercises.length > 0) {
-        return exercises.map(exercise => exercise.replace(/\d+\.\s*/, '').trim()).filter(exercise => exercise.length > 5)
-      }
-    }
-  }
-  
-  return ['Practice exercises', 'Mini-projects', 'Code challenges']
-}
-
-function extractDailyDuration(text: string): number {
-  // Look for duration patterns in the text
-  const patterns = [
-    /(\d+)\s*minutes?/i,
-    /(\d+)\s*mins?/i,
-    /(\d+)\s*hours?/i,
-    /(\d+)\s*hrs?/i
-  ]
-  
-  for (const pattern of patterns) {
-    const match = text.match(pattern)
-    if (match) {
-      const duration = parseInt(match[1])
-      if (duration > 0) {
-        // Convert hours to minutes if needed
-        if (text.toLowerCase().includes('hour') || text.toLowerCase().includes('hr')) {
-          return duration * 60
-        }
-        return duration
-      }
-    }
-  }
-  
-  return 25 // Default to 25 minutes
-}
-
-function extractWeeklySummary(text: string): string {
-  const title = extractDailyTitle(text)
-  if (title !== 'Weekly Learning Module') {
-    return title
-  }
-  return 'Weekly learning module with comprehensive coverage'
-}
-
-function extractDailyBreakdown(text: string): string[] {
-  const patterns = [
-    /Daily Socratic Prompts[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i,
-    /Daily Breakdown[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i,
-    /Week Schedule[^\n]*:([\s\S]*?)(?=\n\s*\d+\.|$)/i
-  ]
-  
-  for (const pattern of patterns) {
-    const breakdownMatch = text.match(pattern)
-    if (breakdownMatch) {
-      const breakdownText = breakdownMatch[1]
-      const breakdown = breakdownText.match(/\d+\.\s*([^\n]+)/g)
-      if (breakdown && breakdown.length > 0) {
-        return breakdown.map(item => item.replace(/\d+\.\s*/, '').trim()).filter(item => item.length > 5)
-      }
-    }
-  }
-  
-  return ['Day 1: Foundation', 'Day 2: Practice', 'Day 3: Application', 'Day 4: Review', 'Day 5: Assessment']
-}
-
-function extractPlanDuration(text: string): number {
-  // Look for week duration patterns
-  const patterns = [
-    /Week (\d+)/i,
-    /(\d+)\s*weeks?/i,
-    /(\d+)\s*days?/i
-  ]
-  
-  for (const pattern of patterns) {
-    const match = text.match(pattern)
-    if (match) {
-      const duration = parseInt(match[1])
-      if (duration > 0 && duration <= 7) {
-        return duration
-      }
-    }
-  }
-  
-  return 5 // Default to 5 days
+async function resolveCurrentWeek() {
+  const start = new Date('2024-01-01').getTime();
+  return Math.ceil((Date.now() - start) / (7 * 24 * 60 * 60 * 1000));
 }

--- a/supabase/functions/instructor-agent/index.ts
+++ b/supabase/functions/instructor-agent/index.ts
@@ -1,301 +1,353 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createFeatherRuntime } from "../_shared/feather/runtime.ts";
+import { FeatherTaskContext } from "../_shared/feather/types.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+type SupabaseClient = ReturnType<typeof createClient>;
+
+interface InstructorProfile {
+  learning_style?: string;
+  end_goal?: string;
+  hardware_specs?: string;
+  premium?: boolean;
+  timezone?: string;
+  track_label?: string;
 }
 
-interface InstructorRequest {
-  action: string;
-  payload: any;
-  userId: string;
+interface InstructorPayload {
+  timePerDay?: number;
+  weekNumber?: number;
+  dayNumber?: number;
+  difficultyLevel?: string;
 }
+
+const runtime = createFeatherRuntime({
+  agentId: "instructor",
+  label: "Instructor Orchestrator",
+  tasks: [
+    {
+      id: "deliver-lecture",
+      phaseId: "lecture",
+      label: "Deliver Lecture",
+      run: runLecturePhase,
+    },
+    {
+      id: "comprehension-check",
+      phaseId: "comprehension",
+      label: "Comprehension Check",
+      run: runComprehensionPhase,
+    },
+    {
+      id: "practice-modification",
+      phaseId: "practice",
+      label: "Practice Personalization",
+      run: runPracticePhase,
+    },
+  ],
+});
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: runtime.corsHeaders });
   }
 
+  const payload = await req.json();
+  const proxy = new Request(req.url, { method: req.method, headers: req.headers, body: JSON.stringify(payload) });
+  return runtime.handleRequest(proxy);
+});
+
+async function runLecturePhase(ctx: FeatherTaskContext) {
+  const supabase = buildSupabase(ctx);
+  const prompt = await loadPrompt(supabase);
+  const profile = await loadProfile(supabase, ctx.request.userId);
+  const calendar = resolveCalendar(ctx.request.payload as InstructorPayload | undefined);
+  ctx.state.calendar = calendar;
+  ctx.state.profile = profile;
+  ctx.state.promptText = prompt;
+
+  const formattedPrompt = formatPrompt(prompt, profile, calendar, ctx.request.payload as InstructorPayload | undefined, ctx.request.action);
+  const lecture = await callGeminiAPI(formattedPrompt, 'DELIVER_LECTURE', ctx.request.payload);
+
+  ctx.state.lecture = lecture.data;
+
+  ctx.emitArtifact({
+    id: `instructor-lecture-${calendar.week}-${calendar.day}`,
+    kind: 'instructor_lecture',
+    label: lecture.data?.title || `Lecture Day ${calendar.day}`,
+    data: lecture.data,
+    meta: { weekNumber: calendar.week, dayNumber: calendar.day, command: 'DELIVER_LECTURE' },
+  });
+
+  ctx.setPhaseSummary('Generated instructor lecture content.');
+}
+
+async function runComprehensionPhase(ctx: FeatherTaskContext) {
+  const supabase = buildSupabase(ctx);
+  const prompt = (ctx.state.promptText as string) || (await loadPrompt(supabase));
+  const calendar = ctx.state.calendar || resolveCalendar(ctx.request.payload as InstructorPayload | undefined);
+  const comprehensionPayload = {
+    ...(ctx.request.payload || {}),
+    lecture_summary: ctx.state.lecture?.lecture_content || ctx.state.lecture,
+  };
+
+  const profile = (ctx.state.profile as InstructorProfile | undefined) || {};
+  const formattedPrompt = formatPrompt(String(prompt), profile, calendar, comprehensionPayload, 'CHECK_COMPREHENSION');
+  const comprehension = await callGeminiAPI(formattedPrompt, 'CHECK_COMPREHENSION', comprehensionPayload);
+
+  ctx.state.comprehension = comprehension.data;
+
+  ctx.emitArtifact({
+    id: `instructor-comprehension-${calendar.week}-${calendar.day}`,
+    kind: 'comprehension_check',
+    label: 'Comprehension Assessment',
+    data: comprehension.data,
+    meta: { questionCount: comprehension.data?.questions?.length ?? 0, command: 'CHECK_COMPREHENSION' },
+  });
+
+  ctx.setPhaseSummary('Generated comprehension check.');
+}
+
+async function runPracticePhase(ctx: FeatherTaskContext) {
+  const supabase = buildSupabase(ctx);
+  const prompt = (ctx.state.promptText as string) || (await loadPrompt(supabase));
+  const calendar = ctx.state.calendar || resolveCalendar(ctx.request.payload as InstructorPayload | undefined);
+  const practicePayload = {
+    ...(ctx.request.payload || {}),
+    comprehension: ctx.state.comprehension,
+    lecture: ctx.state.lecture,
+  };
+
+  const profile = (ctx.state.profile as InstructorProfile | undefined) || {};
+  const formattedPrompt = formatPrompt(String(prompt), profile, calendar, practicePayload, 'MODIFY_PRACTICE_PROMPTS');
+  const practice = await callGeminiAPI(formattedPrompt, 'MODIFY_PRACTICE_PROMPTS', practicePayload);
+
+  ctx.state.practice = practice.data;
+
+  ctx.emitArtifact({
+    id: `instructor-practice-${calendar.week}-${calendar.day}`,
+    kind: 'practice_modification',
+    label: 'Practice Personalization',
+    data: practice.data,
+    meta: { command: 'MODIFY_PRACTICE_PROMPTS' },
+  });
+
+  ctx.setPhaseSummary('Generated practice modifications for TA and Socratic agents.');
+}
+
+function buildSupabase(ctx: FeatherTaskContext): SupabaseClient {
+  if (ctx.supabase) return ctx.supabase as SupabaseClient;
+  const client = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  );
+  ctx.state.supabase = client;
+  return client;
+}
+
+async function loadPrompt(supabase: SupabaseClient) {
   try {
-    const { action, payload, userId }: InstructorRequest = await req.json()
-
-    // Initialize Supabase client
-    const supabaseClient = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
-    )
-
-    // Load instructor prompt from storage (fallback to hardcoded if storage fails)
-    let promptText;
-    try {
-      const { data: promptData, error: promptError } = await supabaseClient.storage
-        .from('agent-prompts')
-        .download('instructor_v2_2.yml')
-
-      if (promptError) {
-        console.log('Storage failed, using hardcoded prompt:', promptError.message);
-        promptText = getHardcodedInstructorPrompt();
-      } else {
-        promptText = await promptData.text();
-      }
-    } catch (error) {
-      console.log('Storage error, using hardcoded prompt:', error.message);
-      promptText = getHardcodedInstructorPrompt();
+    const { data, error } = await supabase.storage.from('agent-prompts').download('instructor_v2_2.yml');
+    if (error || !data) {
+      console.log('Storage download failed, using hardcoded prompt', error?.message);
+      return getHardcodedInstructorPrompt();
     }
-
-    // Get user profile and context
-    const { data: userProfile } = await supabaseClient
-      .from('profiles')
-      .select('*')
-      .eq('id', userId)
-      .single()
-
-    // Get current week and day
-    const currentWeek = Math.ceil((Date.now() - new Date('2024-01-01').getTime()) / (7 * 24 * 60 * 60 * 1000))
-    const currentDay = Math.ceil((Date.now() - new Date('2024-01-01').getTime()) / (24 * 60 * 60 * 1000)) % 5 + 1
-
-    // Format prompt with user context
-    const formattedPrompt = promptText
-      .replace(/{{TRACK_LABEL}}/g, userProfile?.track_label || 'AI/ML Engineering')
-      .replace(/{{WEEK_NUMBER}}/g, currentWeek.toString())
-      .replace(/{{DAY_NUMBER}}/g, currentDay.toString())
-      .replace(/{{TIME_PER_DAY_MIN}}/g, payload.timePerDay || '30')
-      .replace(/{{LEARNING_STYLE}}/g, userProfile?.learning_style || 'mixed')
-      .replace(/{{END_GOAL}}/g, userProfile?.end_goal || 'Master machine learning fundamentals')
-      .replace(/{{HARDWARE_SPECS}}/g, userProfile?.hardware_specs || 'basic laptop')
-      .replace(/{{USER_PREMIUM_BOOL}}/g, (userProfile?.premium || false).toString())
-      .replace(/{{USER_TZ}}/g, userProfile?.timezone || 'UTC')
-
-    // Map our actions to the prompt's expected commands
-    let command;
-    if (action === 'GET_DAILY_LESSON') {
-      command = 'START_DAY';
-    } else if (action === 'GET_NEXT_LESSON') {
-      command = 'REPLAN_LIGHT';
-    } else if (action === 'DELIVER_LECTURE') {
-      command = 'DELIVER_LECTURE';
-    } else if (action === 'CHECK_COMPREHENSION') {
-      command = 'CHECK_COMPREHENSION';
-    } else if (action === 'MODIFY_PRACTICE_PROMPTS') {
-      command = 'MODIFY_PRACTICE_PROMPTS';
-    }
-    
-    // Call Gemini API with formatted prompt
-    const geminiResponse = await callGeminiAPI(formattedPrompt, command, payload, action)
-
-    if (geminiResponse.success) {
-      return new Response(
-        JSON.stringify({ success: true, data: geminiResponse.data }),
-        {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-          status: 200,
-        },
-      )
-    } else {
-      throw new Error(geminiResponse.error)
-    }
-
+    const text = await data.text();
+    return text;
   } catch (error) {
-    return new Response(
-      JSON.stringify({ 
-        success: false, 
-        error: error.message 
-      }),
-      {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 500,
-      },
-    )
-  }
-})
-
-async function callGeminiAPI(prompt: string, command: string, payload: any, originalAction: string) {
-  try {
-    const geminiApiKey = Deno.env.get('GEMINI_API_KEY')
-    if (!geminiApiKey) {
-      throw new Error('GEMINI_API_KEY not configured')
-    }
-
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${geminiApiKey}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        contents: [{
-          parts: [{
-            text: `${prompt}\n\nCommand: ${command}\nPayload: ${JSON.stringify(payload)}\n\nGenerate a response based on the prompt instructions and command. Return structured data in JSON format.`
-          }]
-        }]
-      })
-    })
-
-    const result = await response.json()
-    
-    if (result.candidates && result.candidates[0]?.content?.parts?.[0]?.text) {
-      const responseText = result.candidates[0].content.parts[0].text
-      
-      // Parse response based on action type
-      return {
-        success: true,
-        data: parseInstructorResponse(responseText, originalAction, payload)
-      }
-    } else {
-      throw new Error('Invalid response from Gemini API')
-    }
-  } catch (error) {
-    return {
-      success: false,
-      error: error.message
-    }
+    console.log('Storage error, using hardcoded prompt', error.message);
+    return getHardcodedInstructorPrompt();
   }
 }
 
-// Main response parser for instructor agent
-function parseInstructorResponse(responseText: string, action: string, payload: any) {
-  try {
-    // Try to parse as JSON first
-    const jsonMatch = responseText.match(/\{[\s\S]*\}/)
-    if (jsonMatch) {
-      return JSON.parse(jsonMatch[0])
-    }
-  } catch (e) {
-    // If JSON parsing fails, create structured response
+async function loadProfile(supabase: SupabaseClient, userId: string): Promise<InstructorProfile> {
+  const { data, error } = await supabase.from('profiles').select('*').eq('id', userId).single();
+  if (error) {
+    throw new Error(`Failed to fetch profile: ${error.message}`);
+  }
+  return data as InstructorProfile;
+}
+
+function resolveCalendar(payload: InstructorPayload | undefined) {
+  const week = payload?.weekNumber ?? Math.ceil((Date.now() - new Date('2024-01-01').getTime()) / (7 * 24 * 60 * 60 * 1000));
+  const day = payload?.dayNumber ?? (Math.ceil((Date.now() - new Date('2024-01-01').getTime()) / (24 * 60 * 60 * 1000)) % 5) + 1;
+  return { week, day };
+}
+
+function formatPrompt(
+  template: string,
+  profile: InstructorProfile,
+  calendar: { week: number; day: number },
+  payload: InstructorPayload | Record<string, unknown> | undefined,
+  action: string,
+) {
+  const timePerDay = (payload as InstructorPayload)?.timePerDay || 30;
+  const learningStyle = profile?.learning_style || 'mixed';
+  const endGoal = profile?.end_goal || 'Master machine learning fundamentals';
+  const hardware = profile?.hardware_specs || 'basic laptop';
+  const isPremium = (profile?.premium || false).toString();
+  const timezone = profile?.timezone || 'UTC';
+
+  return template
+    .replace(/{{TRACK_LABEL}}/g, profile?.track_label || 'AI/ML Engineering')
+    .replace(/{{WEEK_NUMBER}}/g, String(calendar.week))
+    .replace(/{{DAY_NUMBER}}/g, String(calendar.day))
+    .replace(/{{TIME_PER_DAY_MIN}}/g, String(timePerDay))
+    .replace(/{{LEARNING_STYLE}}/g, learningStyle)
+    .replace(/{{END_GOAL}}/g, endGoal)
+    .replace(/{{HARDWARE_SPECS}}/g, hardware)
+    .replace(/{{USER_PREMIUM_BOOL}}/g, isPremium)
+    .replace(/{{USER_TZ}}/g, timezone)
+    .concat(`\n\nCommand: ${action}`);
+}
+
+async function callGeminiAPI(prompt: string, command: string, payload: Record<string, unknown> | undefined) {
+  const geminiApiKey = Deno.env.get('GEMINI_API_KEY');
+  if (!geminiApiKey) {
+    throw new Error('GEMINI_API_KEY not configured');
   }
 
-  // Fallback structured response based on action
+  const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${geminiApiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [
+        {
+          parts: [
+            {
+              text: `${prompt}\nPayload: ${JSON.stringify(payload || {})}\n\nGenerate a response based on the prompt instructions and command. Return structured data in JSON format.`,
+            },
+          ],
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Gemini API error: ${response.status} ${response.statusText} - ${errorBody}`);
+  }
+
+  const result = await response.json();
+  const responseText = result?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+  const parsed = parseInstructorResponse(responseText, command, payload);
+  return { success: true, data: parsed };
+}
+
+function parseInstructorResponse(responseText: string, action: string, payload: any) {
+  try {
+    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      return JSON.parse(jsonMatch[0]);
+    }
+  } catch (_error) {
+    // fall back to manual parsing
+  }
+
   switch (action) {
     case 'DELIVER_LECTURE':
       return {
-        lecture_content: extractContent(responseText) || "Today we'll explore the foundational concepts of machine learning. We'll start with understanding what machine learning is, how it differs from traditional programming, and the different types of learning approaches.",
-        key_concepts: extractKeyConcepts(responseText) || ["Supervised Learning", "Unsupervised Learning", "Model Training"],
+        lecture_content: extractContent(responseText) || "Today we'll explore the foundational concepts of the topic.",
+        key_concepts: extractKeyConcepts(responseText) || ['Concept A', 'Concept B'],
         estimated_duration: extractDuration(responseText) || 20,
         next_phase: 'comprehension_check',
         lecture_id: `lecture-${Date.now()}`,
-        difficulty_level: payload.difficultyLevel || 'intermediate'
-      }
+        difficulty_level: (payload?.difficultyLevel as string) || 'intermediate',
+      };
     case 'CHECK_COMPREHENSION':
       return {
         questions: extractComprehensionQuestions(responseText) || [
           { id: 'q1', question: 'What is the difference between supervised and unsupervised learning?' },
-          { id: 'q2', question: 'Explain the concept of model training.' }
+          { id: 'q2', question: 'Explain the concept of model training.' },
         ],
         user_understanding: extractUnderstandingLevel(responseText) || 'intermediate',
         next_phase: 'practice_preparation',
-        assessment_id: `assessment-${Date.now()}`
-      }
+        assessment_id: `assessment-${Date.now()}`,
+      };
     case 'MODIFY_PRACTICE_PROMPTS':
       return {
-        ta_prompt: extractTAPrompt(responseText) || "Modified TA prompt based on user understanding...",
-        socratic_prompt: extractSocraticPrompt(responseText) || "Modified Socratic prompt based on user understanding...",
-        practice_focus: extractPracticeFocus(responseText) || ["reinforcement", "application"],
-        modification_id: `modification-${Date.now()}`
-      }
-    case 'GET_DAILY_LESSON':
-    case 'GET_NEXT_LESSON':
+        ta_prompt: extractTAPrompt(responseText) || 'Modified TA prompt based on user understanding...',
+        socratic_prompt: extractSocraticPrompt(responseText) || 'Modified Socratic prompt based on user understanding...',
+        practice_focus: extractPracticeFocus(responseText) || ['reinforcement', 'application'],
+        modification_id: `modification-${Date.now()}`,
+      };
     default:
       return {
-        lesson_id: `daily-${payload.dayNumber || 1}`,
-        title: extractTitle(responseText),
-        objectives: extractObjectives(responseText),
-        content: extractContent(responseText),
-        exercises: extractExercises(responseText),
-        estimated_duration: extractDuration(responseText),
-        day_number: payload.dayNumber || 1,
-        practice_options: [
-          { type: 'socratic', title: 'Socratic Practice', description: 'Deep dive through questioning' },
-          { type: 'ta', title: 'TA Session', description: 'Get help with exercises' }
-        ]
-      }
+        raw_text: responseText,
+      };
   }
 }
 
-// Helper functions to extract structured data from Gemini response
-function extractTitle(text: string): string {
-  const titleMatch = text.match(/Title[:\s]+([^\n]+)/i)
-  return titleMatch ? titleMatch[1].trim() : 'Daily Learning Session'
+function extractContent(text: string): string | undefined {
+  const match = text.match(/Lecture Content[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  return match ? match[1].trim() : undefined;
 }
 
-function extractObjectives(text: string): string[] {
-  const objectivesMatch = text.match(/Objectives?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  if (objectivesMatch) {
-    return objectivesMatch[1]
+function extractKeyConcepts(text: string): string[] | undefined {
+  const match = text.match(/Key Concepts?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  if (match) {
+    return match[1]
       .split('\n')
-      .map(obj => obj.replace(/^[-*•]\s*/, '').trim())
-      .filter(obj => obj.length > 0)
+      .map((item) => item.replace(/^[-*•]\s*/, '').trim())
+      .filter((item) => item.length > 0);
   }
-  return ['Complete daily objectives']
+  return undefined;
 }
 
-function extractContent(text: string): string {
-  const contentMatch = text.match(/Content[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  return contentMatch ? contentMatch[1].trim() : 'Daily lesson content will appear here.'
+function extractDuration(text: string): number | undefined {
+  const match = text.match(/Duration[:\s]+(\d+)/i);
+  return match ? parseInt(match[1]) : undefined;
 }
 
-function extractExercises(text: string): string[] {
-  const exercisesMatch = text.match(/Exercises?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  if (exercisesMatch) {
-    return exercisesMatch[1]
+function extractComprehensionQuestions(text: string) {
+  const match = text.match(/Questions?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  if (match) {
+    return match[1]
       .split('\n')
-      .map(ex => ex.replace(/^[-*•]\s*/, '').trim())
-      .filter(ex => ex.length > 0)
+      .map((q, index) => ({ id: `q${index + 1}`, question: q.replace(/^[-*•]\s*/, '').trim() }))
+      .filter((item) => item.question.length > 0);
   }
-  return ['Practice exercises']
+  return undefined;
 }
 
-function extractDuration(text: string): number {
-  const durationMatch = text.match(/Duration[:\s]+(\d+)/i)
-  return durationMatch ? parseInt(durationMatch[1]) : 30
+function extractUnderstandingLevel(text: string): string | undefined {
+  const match = text.match(/Understanding Level[:\s]+([\w\s]+)/i);
+  return match ? match[1].trim() : undefined;
 }
 
-function extractKeyConcepts(text: string): string[] {
-  const conceptsMatch = text.match(/Key Concepts?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  if (conceptsMatch) {
-    return conceptsMatch[1]
+function extractTAPrompt(text: string): string | undefined {
+  const match = text.match(/TA Prompt[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  return match ? match[1].trim() : undefined;
+}
+
+function extractSocraticPrompt(text: string): string | undefined {
+  const match = text.match(/Socratic Prompt[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  return match ? match[1].trim() : undefined;
+}
+
+function extractPracticeFocus(text: string): string[] | undefined {
+  const match = text.match(/Practice Focus[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  if (match) {
+    return match[1]
       .split('\n')
-      .map(concept => concept.replace(/^[-*•]\s*/, '').trim())
-      .filter(concept => concept.length > 0)
+      .map((item) => item.replace(/^[-*•]\s*/, '').trim())
+      .filter((item) => item.length > 0);
   }
-  return ['Core concepts']
+  return undefined;
 }
 
-function extractComprehensionQuestions(text: string): Array<{id: string, question: string}> {
-  const questionsMatch = text.match(/Questions?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  if (questionsMatch) {
-    return questionsMatch[1]
-      .split('\n')
-      .map((q, index) => ({
-        id: `q${index + 1}`,
-        question: q.replace(/^[-*•]\s*/, '').trim()
-      }))
-      .filter(q => q.question.length > 0)
-  }
-  return []
-}
+function getHardcodedInstructorPrompt() {
+  return `# Instructor Agent Prompt
 
-function extractUnderstandingLevel(text: string): string {
-  const levelMatch = text.match(/Understanding Level[:\s]+([^\n]+)/i)
-  return levelMatch ? levelMatch[1].trim().toLowerCase() : 'intermediate'
-}
+You are a senior instructor orchestrating a daily learning journey. Use the provided context about the learner, their goals, and the current week/day to deliver lectures, comprehension checks, and practice modifications.
 
-function extractTAPrompt(text: string): string {
-  const taMatch = text.match(/TA Prompt[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  return taMatch ? taMatch[1].trim() : 'Modified TA prompt based on user understanding...'
-}
-
-function extractSocraticPrompt(text: string): string {
-  const socraticMatch = text.match(/Socratic Prompt[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  return socraticMatch ? socraticMatch[1].trim() : 'Modified Socratic prompt based on user understanding...'
-}
-
-function extractPracticeFocus(text: string): string[] {
-  const focusMatch = text.match(/Practice Focus[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  if (focusMatch) {
-    return focusMatch[1]
-      .split('\n')
-      .map(focus => focus.replace(/^[-*•]\s*/, '').trim())
-      .filter(focus => focus.length > 0)
-  }
-  return ['reinforcement', 'application']
+Sections to provide:
+- Lecture Content
+- Key Concepts
+- Duration
+- Comprehension Questions
+- Understanding Level
+- TA Prompt
+- Socratic Prompt
+- Practice Focus
+`;
 }

--- a/supabase/functions/socratic-agent/index.ts
+++ b/supabase/functions/socratic-agent/index.ts
@@ -1,177 +1,216 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createFeatherRuntime } from "../_shared/feather/runtime.ts";
+import { FeatherTaskContext } from "../_shared/feather/types.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+type SupabaseClient = ReturnType<typeof createClient>;
+
+interface SocraticProfile {
+  learning_style?: string;
 }
 
-interface SocraticRequest {
-  action: string;
-  payload: any;
-  userId: string;
-  instructorModifications?: {
-    userUnderstanding: Record<string, string>;
-    instructorNotes: string;
-    practiceFocus: string[];
+interface SocraticPayload {
+  topic?: string;
+  userLevel?: string;
+}
+
+const runtime = createFeatherRuntime({
+  agentId: "socratic",
+  label: "Socratic Facilitator",
+  tasks: [
+    {
+      id: "generate-question",
+      phaseId: "comprehension",
+      label: "Guided Question",
+      run: runQuestionPhase,
+    },
+    {
+      id: "socratic-summary",
+      phaseId: "reflection",
+      label: "Dialogue Summary",
+      run: runSummaryPhase,
+    },
+  ],
+});
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: runtime.corsHeaders });
+  }
+
+  const payload = await req.json();
+  const proxy = new Request(req.url, { method: req.method, headers: req.headers, body: JSON.stringify(payload) });
+  return runtime.handleRequest(proxy);
+});
+
+async function runQuestionPhase(ctx: FeatherTaskContext) {
+  const supabase: SupabaseClient = (ctx.supabase as SupabaseClient) ?? createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  );
+
+  const prompt = await loadPrompt(supabase, 'agent-prompts', 'socratic_v3.yml');
+  const userProfile = await loadProfile(supabase, ctx.request.userId);
+  const formatted = formatPrompt(prompt, userProfile, ctx.request.payload as SocraticPayload, ctx.request.instructorModifications);
+
+  const response = await callGeminiAPI(formatted, ctx.request.action, ctx.request.payload);
+
+  ctx.state.question = response.data;
+
+  ctx.emitArtifact({
+    id: `socratic-question-${response.data.session_id ?? Date.now()}`,
+    kind: "socratic_question",
+    label: response.data.topic || (ctx.request.payload as SocraticPayload)?.topic || 'Guided question',
+    data: response.data,
+    meta: {
+      sessionId: response.data.session_id,
+      masteryLevel: response.data.mastery_level ?? response.data.level ?? 1,
+    },
+  });
+
+  ctx.setPhaseSummary("Generated Socratic dialogue prompt");
+}
+
+async function runSummaryPhase(ctx: FeatherTaskContext) {
+  const question = ctx.state.question ?? {};
+  const summary = {
+    nextAction: question?.next_question || question?.question,
+    masteryLevel: question?.mastery_level ?? question?.level ?? 1,
+    feedback: question?.feedback || 'Keep exploring the concept using Socratic questions.',
+  };
+
+  ctx.emitArtifact({
+    id: `socratic-summary-${Date.now()}`,
+    kind: "session_summary",
+    label: "Socratic Session Summary",
+    data: summary,
+  });
+
+  ctx.setPhaseSummary('Summarized Socratic dialogue session.');
+}
+
+async function loadPrompt(supabase: SupabaseClient, bucket: string, file: string) {
+  const { data, error } = await supabase.storage.from(bucket).download(file);
+  if (error || !data) {
+    throw new Error(`Failed to load Socratic prompt: ${error?.message ?? 'unknown error'}`);
+  }
+  return await data.text();
+}
+
+async function loadProfile(supabase: SupabaseClient, userId: string): Promise<SocraticProfile> {
+  const { data, error } = await supabase.from('profiles').select('*').eq('id', userId).single();
+  if (error) {
+    throw new Error(`Failed to fetch profile: ${error.message}`);
+  }
+  return data as SocraticProfile;
+}
+
+function formatPrompt(
+  template: string,
+  profile: SocraticProfile,
+  payload: SocraticPayload | undefined,
+  instructorModifications: Record<string, unknown> | undefined,
+) {
+  const instructorNotes = (instructorModifications?.["instructorNotes"] as string) || '';
+  const focus = instructorModifications?.["practiceFocus"] as unknown;
+  const focusList = Array.isArray(focus) ? (focus as string[]) : [];
+  const understanding = instructorModifications?.["userUnderstanding"] ?? {};
+
+  return template
+    .replace(/{{TOPIC}}/g, payload?.topic || 'Machine Learning Fundamentals')
+    .replace(/{{LEARNING_STYLE}}/g, profile?.learning_style || 'mixed')
+    .replace(/{{INSTRUCTOR_NOTES}}/g, instructorNotes)
+    .replace(/{{PRACTICE_FOCUS}}/g, focusList.join(', '))
+    .replace(/{{SOCRATIC_FOCUS}}/g, focusList.join(', '))
+    .replace(/{{USER_UNDERSTANDING}}/g, JSON.stringify(understanding));
+}
+
+async function callGeminiAPI(prompt: string, action: string, payload: Record<string, unknown> | undefined) {
+  const geminiApiKey = Deno.env.get('GEMINI_API_KEY');
+  if (!geminiApiKey) {
+    throw new Error('GEMINI_API_KEY not configured');
+  }
+
+  const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${geminiApiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [
+        {
+          parts: [
+            {
+              text: `${prompt}\n\nAction: ${action}\nPayload: ${JSON.stringify(payload || {})}\n\nGenerate a structured response following the prompt instructions.`,
+            },
+          ],
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Gemini API error: ${response.status} ${response.statusText} - ${errorBody}`);
+  }
+
+  const result = await response.json();
+  const text = result?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+
+  const structured = parseSocraticResponse(text, action, payload);
+  return { success: true, data: structured };
+}
+
+function parseSocraticResponse(text: string, action: string, payload: Record<string, unknown> | undefined) {
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      return JSON.parse(jsonMatch[0]);
+    } catch (error) {
+      console.warn('Failed to parse Socratic JSON response', error);
+    }
+  }
+
+  if (action === 'START_SESSION') {
+    return {
+      session_id: crypto.randomUUID(),
+      question: extractQuestion(text),
+      level: extractLevel(text),
+      topic: (payload as SocraticPayload)?.topic || 'Machine Learning Fundamentals',
+    };
+  }
+
+  if (action === 'CONTINUE_SESSION') {
+    return {
+      question: extractQuestion(text),
+      level: extractLevel(text),
+      feedback: extractFeedback(text),
+      mastery_level: extractMasteryLevel(text),
+    };
+  }
+
+  return {
+    question: extractQuestion(text),
+    level: extractLevel(text),
+    feedback: extractFeedback(text),
+    mastery_level: extractMasteryLevel(text),
   };
 }
 
-serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
-  }
-
-  try {
-    const { action, payload, userId, instructorModifications }: SocraticRequest = await req.json()
-
-    // Initialize Supabase client
-    const supabaseClient = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
-    )
-
-    // Load Socratic prompt from storage
-    const { data: promptData, error: promptError } = await supabaseClient.storage
-      .from('agent-prompts')
-      .download('socratic_v3.yml')
-
-    if (promptError) {
-      throw new Error(`Failed to load Socratic prompt: ${promptError.message}`)
-    }
-
-    const promptText = await promptData.text()
-
-    // Get user profile and context
-    const { data: userProfile } = await supabaseClient
-      .from('profiles')
-      .select('*')
-      .eq('id', userId)
-      .single()
-
-    // Format prompt with user context and instructor modifications
-    const formattedPrompt = promptText
-      .replace(/{{TOPIC}}/g, payload.topic || 'Machine Learning Fundamentals')
-      .replace(/{{LEARNING_STYLE}}/g, userProfile?.learning_style || 'mixed')
-      .replace(/{{INSTRUCTOR_NOTES}}/g, instructorModifications?.instructorNotes || '')
-      .replace(/{{PRACTICE_FOCUS}}/g, instructorModifications?.practiceFocus?.join(', ') || '')
-      .replace(/{{SOCRATIC_FOCUS}}/g, instructorModifications?.practiceFocus?.join(', ') || '')
-      .replace(/{{USER_UNDERSTANDING}}/g, JSON.stringify(instructorModifications?.userUnderstanding || {}))
-
-    // Call Gemini API with formatted prompt
-    const geminiResponse = await callGeminiAPI(formattedPrompt, action, payload)
-
-    if (geminiResponse.success) {
-      return new Response(
-        JSON.stringify({ success: true, data: geminiResponse.data }),
-        {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-          status: 200,
-        },
-      )
-    } else {
-      throw new Error(geminiResponse.error)
-    }
-
-  } catch (error) {
-    return new Response(
-      JSON.stringify({ 
-        success: false, 
-        error: error.message 
-      }),
-      {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 500,
-      },
-    )
-  }
-})
-
-async function callGeminiAPI(prompt: string, action: string, payload: any) {
-  try {
-    const geminiApiKey = Deno.env.get('GEMINI_API_KEY')
-    if (!geminiApiKey) {
-      throw new Error('GEMINI_API_KEY not configured')
-    }
-
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${geminiApiKey}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        contents: [{
-          parts: [{
-            text: `${prompt}\n\nAction: ${action}\nPayload: ${JSON.stringify(payload)}\n\nGenerate a response based on the prompt instructions.`
-          }]
-        }]
-      })
-    })
-
-    const result = await response.json()
-    
-    if (result.candidates && result.candidates[0]?.content?.parts?.[0]?.text) {
-      const responseText = result.candidates[0].content.parts[0].text
-      
-      if (action === 'START_SESSION') {
-        return {
-          success: true,
-          data: {
-            session_id: crypto.randomUUID(),
-            question: extractQuestion(responseText),
-            level: extractLevel(responseText),
-            topic: payload.topic || 'Machine Learning Fundamentals'
-          }
-        }
-      } else if (action === 'CONTINUE_SESSION') {
-        return {
-          success: true,
-          data: {
-            question: extractQuestion(responseText),
-            level: extractLevel(responseText),
-            feedback: extractFeedback(responseText),
-            mastery_level: extractMasteryLevel(responseText)
-          }
-        }
-      } else if (action === 'ASSESS_MASTERY') {
-        return {
-          success: true,
-          data: {
-            mastery_level: extractMasteryLevel(responseText),
-            next_question: extractQuestion(responseText),
-            level: extractLevel(responseText),
-            is_mastered: extractMasteryLevel(responseText) >= 5
-          }
-        }
-      }
-    } else {
-      throw new Error('Invalid response from Gemini API')
-    }
-  } catch (error) {
-    return {
-      success: false,
-      error: error.message
-    }
-  }
-}
-
-// Helper functions to extract structured data from Gemini response
 function extractQuestion(text: string): string {
-  const questionMatch = text.match(/Question[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  return questionMatch ? questionMatch[1].trim() : 'What do you think about this concept?'
+  const questionMatch = text.match(/Question[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  return questionMatch ? questionMatch[1].trim() : 'What do you think about this concept?';
 }
 
 function extractLevel(text: string): number {
-  const levelMatch = text.match(/Level[:\s]+(\d+)/i)
-  return levelMatch ? parseInt(levelMatch[1]) : 1
+  const levelMatch = text.match(/Level[:\s]+(\d+)/i);
+  return levelMatch ? parseInt(levelMatch[1]) : 1;
 }
 
 function extractFeedback(text: string): string {
-  const feedbackMatch = text.match(/Feedback[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  return feedbackMatch ? feedbackMatch[1].trim() : 'Good understanding. Let\'s continue.'
+  const feedbackMatch = text.match(/Feedback[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  return feedbackMatch ? feedbackMatch[1].trim() : 'Let\'s explore this further.';
 }
 
 function extractMasteryLevel(text: string): number {
-  const masteryMatch = text.match(/Mastery Level[:\s]+(\d+)/i)
-  return masteryMatch ? parseInt(masteryMatch[1]) : 3
+  const masteryMatch = text.match(/Mastery Level[:\s]+(\d+)/i);
+  return masteryMatch ? parseInt(masteryMatch[1]) : 3;
 }

--- a/supabase/functions/ta-agent/index.ts
+++ b/supabase/functions/ta-agent/index.ts
@@ -1,240 +1,289 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createFeatherRuntime } from "../_shared/feather/runtime.ts";
+import { FeatherTaskContext } from "../_shared/feather/types.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+type SupabaseClient = ReturnType<typeof createClient>;
+
+interface TAProfile {
+  learning_style?: string;
 }
 
-interface TARequest {
-  action: string;
-  payload: any;
-  userId: string;
-  instructorModifications?: {
-    userUnderstanding: Record<string, string>;
-    instructorNotes: string;
-    practiceFocus: string[];
+interface TAPayload {
+  topic?: string;
+  userLevel?: string;
+  exerciseId?: string;
+  concept?: string;
+}
+
+const runtime = createFeatherRuntime({
+  agentId: "ta",
+  label: "Teaching Assistant",
+  tasks: [
+    {
+      id: "ta-support",
+      phaseId: "practice",
+      label: "Practice Support",
+      run: runSupportPhase,
+    },
+    {
+      id: "ta-summary",
+      phaseId: "reflection",
+      label: "TA Summary",
+      run: runSummaryPhase,
+    },
+  ],
+});
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: runtime.corsHeaders });
+  }
+
+  const payload = await req.json();
+  const proxy = new Request(req.url, { method: req.method, headers: req.headers, body: JSON.stringify(payload) });
+  return runtime.handleRequest(proxy);
+});
+
+async function runSupportPhase(ctx: FeatherTaskContext) {
+  const supabase: SupabaseClient = (ctx.supabase as SupabaseClient) ?? createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  );
+
+  const prompt = await loadPrompt(supabase, 'agent-prompts', 'taagent_v1_4.yml');
+  const profile = await loadProfile(supabase, ctx.request.userId);
+  const formatted = formatPrompt(prompt, profile, ctx.request.payload as TAPayload, ctx.request.instructorModifications);
+
+  const response = await callGeminiAPI(formatted, ctx.request.action, ctx.request.payload);
+  ctx.state.support = response.data;
+
+  ctx.emitArtifact({
+    id: `ta-support-${Date.now()}`,
+    kind: "ta_guidance",
+    label: `TA Support for ${(ctx.request.payload as TAPayload)?.topic || 'practice task'}`,
+    data: response.data,
+  });
+
+  ctx.setPhaseSummary('Generated TA support directives.');
+}
+
+async function runSummaryPhase(ctx: FeatherTaskContext) {
+  const support = ctx.state.support ?? {};
+  const summary = {
+    primaryAction: support?.next_steps?.[0] || support?.next_steps || support?.help_text,
+    score: support?.score,
+    completed: support?.is_completed ?? false,
+  };
+
+  ctx.emitArtifact({
+    id: `ta-summary-${Date.now()}`,
+    kind: "session_summary",
+    label: 'TA Session Summary',
+    data: summary,
+  });
+
+  ctx.setPhaseSummary('Summarized TA session.');
+}
+
+async function loadPrompt(supabase: SupabaseClient, bucket: string, file: string) {
+  const { data, error } = await supabase.storage.from(bucket).download(file);
+  if (error || !data) {
+    throw new Error(`Failed to load TA prompt: ${error?.message ?? 'unknown error'}`);
+  }
+  return await data.text();
+}
+
+async function loadProfile(supabase: SupabaseClient, userId: string): Promise<TAProfile> {
+  const { data, error } = await supabase.from('profiles').select('*').eq('id', userId).single();
+  if (error) {
+    throw new Error(`Failed to fetch profile: ${error.message}`);
+  }
+  return data as TAProfile;
+}
+
+function formatPrompt(
+  template: string,
+  profile: TAProfile,
+  payload: TAPayload | undefined,
+  instructorModifications: Record<string, unknown> | undefined,
+) {
+  const practiceFocus = instructorModifications?.['practiceFocus'] as unknown;
+  const focusList = Array.isArray(practiceFocus) ? (practiceFocus as string[]) : [];
+  const understanding = instructorModifications?.['userUnderstanding'] ?? {};
+  const instructorNotes = (instructorModifications?.['instructorNotes'] as string) || '';
+
+  return template
+    .replace(/{{TOPIC}}/g, payload?.topic || 'Machine Learning Fundamentals')
+    .replace(/{{LEARNING_STYLE}}/g, profile?.learning_style || 'mixed')
+    .replace(/{{USER_LEVEL}}/g, payload?.userLevel || 'beginner')
+    .replace(/{{INSTRUCTOR_NOTES}}/g, instructorNotes)
+    .replace(/{{PRACTICE_FOCUS}}/g, focusList.join(', '))
+    .replace(/{{USER_UNDERSTANDING}}/g, JSON.stringify(understanding));
+}
+
+async function callGeminiAPI(prompt: string, action: string, payload: Record<string, unknown> | undefined) {
+  const geminiApiKey = Deno.env.get('GEMINI_API_KEY');
+  if (!geminiApiKey) {
+    throw new Error('GEMINI_API_KEY not configured');
+  }
+
+  const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${geminiApiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [
+        {
+          parts: [
+            {
+              text: `${prompt}\n\nAction: ${action}\nPayload: ${JSON.stringify(payload || {})}\n\nGenerate a structured response following the prompt instructions.`,
+            },
+          ],
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Gemini API error: ${response.status} ${response.statusText} - ${errorBody}`);
+  }
+
+  const result = await response.json();
+  const text = result?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+  const structured = parseTAResponse(text, action, payload as TAPayload | undefined);
+  return { success: true, data: structured };
+}
+
+function parseTAResponse(text: string, action: string, payload: TAPayload | undefined) {
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      return JSON.parse(jsonMatch[0]);
+    } catch (error) {
+      console.warn('Failed to parse TA JSON response', error);
+    }
+  }
+
+  if (action === 'HELP_WITH_EXERCISE') {
+    return {
+      exercise_id: payload?.exerciseId || 'exercise-1',
+      help_text: extractHelpText(text),
+      hints: extractHints(text),
+      solution_steps: extractSolutionSteps(text),
+      is_completed: false,
+    };
+  }
+
+  if (action === 'REVIEW_CODE') {
+    return {
+      review_id: crypto.randomUUID(),
+      feedback: extractFeedback(text),
+      suggestions: extractSuggestions(text),
+      score: extractScore(text),
+      max_score: 10,
+      next_steps: extractNextSteps(text),
+    };
+  }
+
+  if (action === 'EXPLAIN_CONCEPT') {
+    return {
+      concept: payload?.concept || 'Machine Learning',
+      explanation: extractExplanation(text),
+      examples: extractExamples(text),
+      analogies: extractAnalogies(text),
+    };
+  }
+
+  return {
+    help_text: extractHelpText(text),
+    hints: extractHints(text),
+    solution_steps: extractSolutionSteps(text),
   };
 }
 
-serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
-  }
-
-  try {
-    const { action, payload, userId, instructorModifications }: TARequest = await req.json()
-
-    // Initialize Supabase client
-    const supabaseClient = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
-    )
-
-    // Load TA prompt from storage
-    const { data: promptData, error: promptError } = await supabaseClient.storage
-      .from('agent-prompts')
-      .download('taagent_v1_4.yml')
-
-    if (promptError) {
-      throw new Error(`Failed to load TA prompt: ${promptError.message}`)
-    }
-
-    const promptText = await promptData.text()
-
-    // Get user profile and context
-    const { data: userProfile } = await supabaseClient
-      .from('profiles')
-      .select('*')
-      .eq('id', userId)
-      .single()
-
-    // Format prompt with user context and instructor modifications
-    const formattedPrompt = promptText
-      .replace(/{{TOPIC}}/g, payload.topic || 'Machine Learning Fundamentals')
-      .replace(/{{LEARNING_STYLE}}/g, userProfile?.learning_style || 'mixed')
-      .replace(/{{USER_LEVEL}}/g, payload.userLevel || 'beginner')
-      .replace(/{{INSTRUCTOR_NOTES}}/g, instructorModifications?.instructorNotes || '')
-      .replace(/{{PRACTICE_FOCUS}}/g, instructorModifications?.practiceFocus?.join(', ') || '')
-      .replace(/{{USER_UNDERSTANDING}}/g, JSON.stringify(instructorModifications?.userUnderstanding || {}))
-
-    // Call Gemini API with formatted prompt
-    const geminiResponse = await callGeminiAPI(formattedPrompt, action, payload)
-
-    if (geminiResponse.success) {
-      return new Response(
-        JSON.stringify({ success: true, data: geminiResponse.data }),
-        {
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-          status: 200,
-        },
-      )
-    } else {
-      throw new Error(geminiResponse.error)
-    }
-
-  } catch (error) {
-    return new Response(
-      JSON.stringify({ 
-        success: false, 
-        error: error.message 
-      }),
-      {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 500,
-      },
-    )
-  }
-})
-
-async function callGeminiAPI(prompt: string, action: string, payload: any) {
-  try {
-    const geminiApiKey = Deno.env.get('GEMINI_API_KEY')
-    if (!geminiApiKey) {
-      throw new Error('GEMINI_API_KEY not configured')
-    }
-
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${geminiApiKey}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        contents: [{
-          parts: [{
-            text: `${prompt}\n\nAction: ${action}\nPayload: ${JSON.stringify(payload)}\n\nGenerate a response based on the prompt instructions.`
-          }]
-        }]
-      })
-    })
-
-    const result = await response.json()
-    
-    if (result.candidates && result.candidates[0]?.content?.parts?.[0]?.text) {
-      const responseText = result.candidates[0].content.parts[0].text
-      
-      if (action === 'HELP_WITH_EXERCISE') {
-        return {
-          success: true,
-          data: {
-            exercise_id: payload.exerciseId || 'ex-1',
-            help_text: extractHelpText(responseText),
-            hints: extractHints(responseText),
-            solution_steps: extractSolutionSteps(responseText),
-            is_completed: false
-          }
-        }
-      } else if (action === 'REVIEW_CODE') {
-        return {
-          success: true,
-          data: {
-            review_id: crypto.randomUUID(),
-            feedback: extractFeedback(responseText),
-            suggestions: extractSuggestions(responseText),
-            score: extractScore(responseText),
-            max_score: 10,
-            next_steps: extractNextSteps(responseText)
-          }
-        }
-      } else if (action === 'EXPLAIN_CONCEPT') {
-        return {
-          success: true,
-          data: {
-            concept: payload.concept || 'Machine Learning',
-            explanation: extractExplanation(responseText),
-            examples: extractExamples(responseText),
-            analogies: extractAnalogies(responseText)
-          }
-        }
-      }
-    } else {
-      throw new Error('Invalid response from Gemini API')
-    }
-  } catch (error) {
-    return {
-      success: false,
-      error: error.message
-    }
-  }
-}
-
-// Helper functions to extract structured data from Gemini response
 function extractHelpText(text: string): string {
-  const helpMatch = text.match(/Help Text[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  return helpMatch ? helpMatch[1].trim() : 'Let me help you with this exercise step by step.'
+  const helpMatch = text.match(/Help Text[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  return helpMatch ? helpMatch[1].trim() : 'Let me help you with this exercise step by step.';
 }
 
 function extractHints(text: string): string[] {
-  const hintsMatch = text.match(/Hints?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
+  const hintsMatch = text.match(/Hints?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
   if (hintsMatch) {
     return hintsMatch[1]
       .split('\n')
-      .map(hint => hint.replace(/^[-*•]\s*/, '').trim())
-      .filter(hint => hint.length > 0)
+      .map((hint) => hint.replace(/^[-*•]\s*/, '').trim())
+      .filter((hint) => hint.length > 0);
   }
-  return ['Start with the basics', 'Break it down step by step']
+  return ['Start with the basics', 'Break it down step by step'];
 }
 
 function extractSolutionSteps(text: string): string[] {
-  const stepsMatch = text.match(/Solution Steps?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
+  const stepsMatch = text.match(/Solution Steps?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
   if (stepsMatch) {
     return stepsMatch[1]
       .split('\n')
-      .map(step => step.replace(/^[-*•]\s*/, '').trim())
-      .filter(step => step.length > 0)
+      .map((step) => step.replace(/^[-*•]\s*/, '').trim())
+      .filter((step) => step.length > 0);
   }
-  return ['Step 1: Understand the problem', 'Step 2: Plan your approach', 'Step 3: Implement the solution']
+  return ['Step 1: Understand the problem', 'Step 2: Plan your approach', 'Step 3: Implement the solution'];
 }
 
 function extractFeedback(text: string): string {
-  const feedbackMatch = text.match(/Feedback[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  return feedbackMatch ? feedbackMatch[1].trim() : 'Your code shows good understanding of the concepts.'
+  const feedbackMatch = text.match(/Feedback[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  return feedbackMatch ? feedbackMatch[1].trim() : 'Your code shows good understanding of the concepts.';
 }
 
 function extractSuggestions(text: string): string[] {
-  const suggestionsMatch = text.match(/Suggestions?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
+  const suggestionsMatch = text.match(/Suggestions?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
   if (suggestionsMatch) {
     return suggestionsMatch[1]
       .split('\n')
-      .map(suggestion => suggestion.replace(/^[-*•]\s*/, '').trim())
-      .filter(suggestion => suggestion.length > 0)
+      .map((suggestion) => suggestion.replace(/^[-*•]\s*/, '').trim())
+      .filter((suggestion) => suggestion.length > 0);
   }
-  return ['Consider adding error handling', 'Improve variable naming']
+  return ['Refine your variable naming', 'Add more comments for clarity'];
 }
 
 function extractScore(text: string): number {
-  const scoreMatch = text.match(/Score[:\s]+(\d+)/i)
-  return scoreMatch ? parseInt(scoreMatch[1]) : 7
+  const scoreMatch = text.match(/Score[:\s]+(\d+)/i);
+  return scoreMatch ? parseInt(scoreMatch[1]) : 7;
 }
 
-function extractNextSteps(text: string): string {
-  const nextStepsMatch = text.match(/Next Steps?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  return nextStepsMatch ? nextStepsMatch[1].trim() : 'Try implementing the suggested improvements.'
+function extractNextSteps(text: string): string[] {
+  const nextMatch = text.match(/Next Steps?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  if (nextMatch) {
+    return nextMatch[1]
+      .split('\n')
+      .map((step) => step.replace(/^[-*•]\s*/, '').trim())
+      .filter((step) => step.length > 0);
+  }
+  return ['Refactor the solution', 'Write unit tests'];
 }
 
 function extractExplanation(text: string): string {
-  const explanationMatch = text.match(/Explanation[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  return explanationMatch ? explanationMatch[1].trim() : 'Let me explain this concept in simple terms.'
+  const match = text.match(/Explanation[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  return match ? match[1].trim() : 'Here is a detailed explanation of the concept.';
 }
 
 function extractExamples(text: string): string[] {
-  const examplesMatch = text.match(/Examples?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  if (examplesMatch) {
-    return examplesMatch[1]
+  const match = text.match(/Examples?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  if (match) {
+    return match[1]
       .split('\n')
-      .map(example => example.replace(/^[-*•]\s*/, '').trim())
-      .filter(example => example.length > 0)
+      .map((example) => example.replace(/^[-*•]\s*/, '').trim())
+      .filter((example) => example.length > 0);
   }
-  return ['Email spam detection', 'Recommendation systems', 'Image recognition']
+  return ['Example 1', 'Example 2'];
 }
 
 function extractAnalogies(text: string): string[] {
-  const analogiesMatch = text.match(/Analogies?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i)
-  if (analogiesMatch) {
-    return analogiesMatch[1]
+  const match = text.match(/Analogies?[:\s]+([\s\S]*?)(?=\n\n|\n[A-Z]|$)/i);
+  if (match) {
+    return match[1]
       .split('\n')
-      .map(analogy => analogy.replace(/^[-*•]\s*/, '').trim())
-      .filter(analogy => analogy.length > 0)
+      .map((analogy) => analogy.replace(/^[-*•]\s*/, '').trim())
+      .filter((analogy) => analogy.length > 0);
   }
-  return ['Like teaching a child to recognize animals', 'Similar to learning to ride a bike through practice']
+  return ['Think of it like building blocks that combine into a structure.'];
 }


### PR DESCRIPTION
## Summary
- include payload-aware hashing in the agent orchestrator cache to avoid stale responses when using feather runs
- expand the Socratic chat workflow to resolve the active week, request a feather START_SESSION prompt, and send CONTINUE_SESSION payloads with history
- ensure the feather agent client forwards the Supabase anon key as both Authorization and apikey headers and normalize manifest formatting

## Testing
- npm run lint *(fails: repository has 500+ pre-existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ffb09e1f98832792eee188b8dd78ef